### PR TITLE
Create Ntasks Flexibility Function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "xarray>=2023.12,<2024",
   "black>=24.1,<24.2",
   "pytest>=8.0,<8.1",
-  "hypothesis>=6.125.1<6.2"
+  "hypothesis>=6.125.1,<6.126"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
   "netcdf4>=1.6,<1.7",
   "xarray>=2023.12,<2024",
   "black>=24.1,<24.2",
-  "pytest>=8.0,<8.1"
+  "pytest>=8.0,<8.1",
+  "hypothesis>=6.125.1<6.2"
 ]
 
 [build-system]

--- a/tests/1_unit/test_cores_case_creator.py
+++ b/tests/1_unit/test_cores_case_creator.py
@@ -4,16 +4,21 @@ from visualCaseGen.custom_widget_types.case_creator import CaseCreator
 
 @given(integers(min_value=1, max_value=1e8))
 def test_calc_cores_based_on_grid_all_values(num_points):
-    """Test that the number of cores is calculated correctly based on the grid."""
+    """Test that the number of points doesn't impact the default run of this function"""
     assert CaseCreator._calc_cores_based_on_grid(num_points)
 
 
 def test_calc_cores_based_on_grid_cases():
+    """Test that the number of cores is calculated correctly based on the number of points"""
+    # Test minimum possible cores is 16
     assert CaseCreator._calc_cores_based_on_grid(1) == 16
 
+    # Test arbitrary number of points
     assert CaseCreator._calc_cores_based_on_grid(32) == 16
 
+    # Test bumping one iteration up from the default (128+16) based on maximum allowed points per core
     assert CaseCreator._calc_cores_based_on_grid(801*128) == 144
 
+    # Test dropping one iteration up from the default (128-16) based on minimum allowed points per core
     assert CaseCreator._calc_cores_based_on_grid(128*32 -1 ) == 112
     

--- a/tests/1_unit/test_cores_case_creator.py
+++ b/tests/1_unit/test_cores_case_creator.py
@@ -1,0 +1,19 @@
+from hypothesis.strategies import integers
+from hypothesis import given
+from visualCaseGen.custom_widget_types.case_creator import CaseCreator
+
+@given(integers(min_value=1, max_value=1e8))
+def test_calc_cores_based_on_grid_all_values(num_points):
+    """Test that the number of cores is calculated correctly based on the grid."""
+    assert CaseCreator._calc_cores_based_on_grid(num_points)
+
+
+def test_calc_cores_based_on_grid_cases():
+    assert CaseCreator._calc_cores_based_on_grid(1) == 16
+
+    assert CaseCreator._calc_cores_based_on_grid(32) == 16
+
+    assert CaseCreator._calc_cores_based_on_grid(801*128) == 144
+
+    assert CaseCreator._calc_cores_based_on_grid(128*32 -1 ) == 112
+    

--- a/tests/1_unit/test_cores_case_creator.py
+++ b/tests/1_unit/test_cores_case_creator.py
@@ -10,15 +10,18 @@ def test_calc_cores_based_on_grid_all_values(num_points):
 
 def test_calc_cores_based_on_grid_cases():
     """Test that the number of cores is calculated correctly based on the number of points"""
-    # Test minimum possible cores is 16
-    assert CaseCreator._calc_cores_based_on_grid(1) == 16
+    # Test minimum possible cores is 1
+    assert CaseCreator._calc_cores_based_on_grid(1) == 1
 
-    # Test arbitrary number of points
-    assert CaseCreator._calc_cores_based_on_grid(32) == 16
+    # Test one under the min pts
+    assert CaseCreator._calc_cores_based_on_grid(33) == 1
 
-    # Test bumping one iteration up from the default (128+16) based on maximum allowed points per core
-    assert CaseCreator._calc_cores_based_on_grid(801*128) == 144
+    # Test ideal cores amount
+    assert CaseCreator._calc_cores_based_on_grid(800*128) == 128
 
-    # Test dropping one iteration up from the default (128-16) based on minimum allowed points per core
-    assert CaseCreator._calc_cores_based_on_grid(128*32 -1 ) == 112
+    assert CaseCreator._calc_cores_based_on_grid(800*32) == 128
+
+    assert CaseCreator._calc_cores_based_on_grid(740 * 780) == 768
+
+
     

--- a/visualCaseGen/custom_widget_types/case_creator.py
+++ b/visualCaseGen/custom_widget_types/case_creator.py
@@ -502,25 +502,28 @@ class CaseCreator:
         else:
             assert lnd_grid_mode in [None, "", "Standard"], f"Unknown land grid mode: {lnd_grid_mode}"
 
-        # Set NTASKS based on grid size. e.g. NX * NY < max_pts_per_core
-        self._set_ntasks_based_on_grid(self, do_exec)
+        # Set NTASKS_OCN based on grid size. e.g. NX * NY < max_pts_per_core
+        self._set_ntasks_ocean_based_on_grid(do_exec)
 
-    def _set_ntasks_based_on_grid(self, do_exec, min_points_per_core = 16, max_points_per_core = 800):
-        """Set NTASKS based on Grid Size"""
+    def _set_ntasks_ocean_based_on_grid(self, do_exec, min_points_per_core = 32, max_points_per_core = 800):
+        """Set NTASKS OCN based on Grid Size"""
+
+        with self._out:
+            print(f"{COMMENT}Apply NTASK grid xml changes:{RESET}\n")
         num_points = int(cvars["OCN_NX"].value) * int(cvars["OCN_NY"].value)
-        cores = 128 # Default
-
+        cores = 128 # Start from 128 which is the default 128 cores per node in derecho
+        iteration_amount = 16
         pts_per_core = num_points/cores
         
         while pts_per_core > max_points_per_core:
-            cores = cores + 1
+            cores = cores + iteration_amount
             pts_per_core = num_points/cores
 
-        while pts_per_core < min_points_per_core:
-            cores = cores - 1
+        while pts_per_core < min_points_per_core and cores > 1: # Don't let cores get below 1
+            cores = cores - iteration_amount
             pts_per_core = num_points/cores
 
-        xmlchange("NTASKS",cores, do_exec, self.is_non_local(), self._out)
+        xmlchange("NTASKS_OCN",cores, do_exec, self._is_non_local(), self._out)
         return
 
     def _apply_user_nl_changes(self, model, var_val_pairs, do_exec, comment=None, log_title=True):

--- a/visualCaseGen/custom_widget_types/case_creator.py
+++ b/visualCaseGen/custom_widget_types/case_creator.py
@@ -506,29 +506,30 @@ class CaseCreator:
 
         # Set NTASKS based on grid size. e.g. NX * NY < max_pts_per_core
         num_points = int(cvars["OCN_NX"].value) * int(cvars["OCN_NY"].value)
-        cores = CaseCreator._set_cores_based_on_grid(num_points)
+        cores = CaseCreator._calc_cores_based_on_grid(num_points)
         with self._out:
             print(f"{COMMENT}Apply NTASK grid xml changes:{RESET}\n")
             xmlchange("NTASKS_OCN",cores, do_exec, self._is_non_local(), self._out)
 
     @staticmethod
-    def _set_cores_based_on_grid( num_points, min_points_per_core = 32, max_points_per_core = 800):
+    def _calc_cores_based_on_grid( num_points, min_points_per_core = 32, max_points_per_core = 800):
         """Calculate the number of cores based on the grid size."""
 
 
         cores = 128 # Start from 128 which is the default 128 cores per node in derecho
         iteration_amount = 16
-        pts_per_core = num_points/cores
+        pts_per_core = num_points/float(cores)
         
         while pts_per_core > max_points_per_core:
             cores = cores + iteration_amount
             pts_per_core = num_points/cores
 
-        while pts_per_core < min_points_per_core and cores > 1: # Don't let cores get below 1
+        while pts_per_core < min_points_per_core and cores > iteration_amount: # Don't let cores get below iteration amount
             cores = cores - iteration_amount
             pts_per_core = num_points/cores
+
+
         return cores
-        return
 
     def _apply_user_nl_changes(self, model, var_val_pairs, do_exec, comment=None, log_title=True):
         """Apply changes to a given user_nl file."""

--- a/visualCaseGen/custom_widget_types/case_creator.py
+++ b/visualCaseGen/custom_widget_types/case_creator.py
@@ -519,9 +519,9 @@ class CaseCreator:
         max_cores = math.ceil(num_points/min_points_per_core)    
 
         # Request a multiple of the entire core (ideal_multiple_of_cores_used) starting from the min
-        ideal_cores_amount = ((min_cores + ideal_multiple_of_cores_used - 1) // ideal_multiple_of_cores_used) * ideal_multiple_of_cores_used
-        if ideal_cores_amount <= max_cores:
-            return ideal_cores_amount
+        ideal_cores = ((min_cores + ideal_multiple_of_cores_used - 1) // ideal_multiple_of_cores_used) * ideal_multiple_of_cores_used
+        if ideal_cores <= max_cores:
+            return ideal_cores
         else:
             return (max_cores+min_cores)//2
 

--- a/visualCaseGen/custom_widget_types/case_creator.py
+++ b/visualCaseGen/custom_widget_types/case_creator.py
@@ -502,15 +502,15 @@ class CaseCreator:
         else:
             assert lnd_grid_mode in [None, "", "Standard"], f"Unknown land grid mode: {lnd_grid_mode}"
 
-        # Set NTASKS_OCN based on grid size. e.g. NX * NY < max_pts_per_core
-        self._set_ntasks_ocean_based_on_grid(do_exec)
+        # Set NTASKS based on grid size. e.g. NX * NY < max_pts_per_core
+        num_points = int(cvars["OCN_NX"].value) * int(cvars["OCN_NY"].value)
+        self._set_ntasks_based_on_grid(do_exec, num_points)
 
-    def _set_ntasks_ocean_based_on_grid(self, do_exec, min_points_per_core = 32, max_points_per_core = 800):
+    def _set_ntasks_based_on_grid(self, do_exec, num_points, min_points_per_core = 32, max_points_per_core = 800):
         """Set NTASKS OCN based on Grid Size"""
 
         with self._out:
             print(f"{COMMENT}Apply NTASK grid xml changes:{RESET}\n")
-        num_points = int(cvars["OCN_NX"].value) * int(cvars["OCN_NY"].value)
         cores = 128 # Start from 128 which is the default 128 cores per node in derecho
         iteration_amount = 16
         pts_per_core = num_points/cores
@@ -523,7 +523,7 @@ class CaseCreator:
             cores = cores - iteration_amount
             pts_per_core = num_points/cores
 
-        xmlchange("NTASKS_OCN",cores, do_exec, self._is_non_local(), self._out)
+        xmlchange("NTASKS",cores, do_exec, self._is_non_local(), self._out)
         return
 
     def _apply_user_nl_changes(self, model, var_val_pairs, do_exec, comment=None, log_title=True):

--- a/visualCaseGen/custom_widget_types/case_creator.py
+++ b/visualCaseGen/custom_widget_types/case_creator.py
@@ -518,8 +518,8 @@ class CaseCreator:
         min_cores = math.ceil(num_points/max_points_per_core)
         max_cores = math.ceil(num_points/min_points_per_core)    
 
-        # Request a multiple of the entire core (128) starting from the min
-        ideal_cores_amount = (min_cores + 127) //128 * 128
+        # Request a multiple of the entire core (ideal_multiple_of_cores_used) starting from the min
+        ideal_cores_amount = ((min_cores + ideal_multiple_of_cores_used - 1) // ideal_multiple_of_cores_used) * ideal_multiple_of_cores_used
         if ideal_cores_amount <= max_cores:
             return ideal_cores_amount
         else:

--- a/visualCaseGen/custom_widget_types/case_creator.py
+++ b/visualCaseGen/custom_widget_types/case_creator.py
@@ -112,8 +112,6 @@ class CaseCreator:
         if cvars["COMPSET_MODE"].value == "Standard":
             compset = cvars["COMPSET_ALIAS"].value
         elif cvars["COMPSET_MODE"].value == "Custom":
-            with self._out:
-                print(f"{COMMENT}{cvars["COMPSET_LNAME"].value}{RESET}\n")
             compset = cvars["COMPSET_LNAME"].value
         else:
             raise RuntimeError(f"Unknown compset mode: {cvars['COMPSET_MODE'].value}")


### PR DESCRIPTION
Create a function that adjusts the number of ntasks based on grid size.

Companion PR that has the demo that resulted in this function (in CrocoDash): https://github.com/CROCODILE-CESM/CrocoDash/pull/28

Questions

- Should I call it "ntasks" or the function should called set_cores_based_on_grid instead
- Currently, cvars has OCN_NX & OCN_NY, I have only set NTASKS_OCN based on that, but should it be for every component?
- In Regional CaseGen, the idea was to request NTASKS as a multiple of the number of cores per node (128) because of some efficiency reason, currently it's set to request more NTASKS in multiples  of 16 if there is more points per core than recommended , but should that actually be 128? The reason it is 16  is because, for reducing the number of NTASKS, 16 works well b/c we need a denomination lower than the cores per node to stop the "MPP_DEFINE_DOMAINS(mpp_compute_extent): domain extents must be positive definite." error.