### PR TITLE
Edit VCG CI to work on forks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,8 +7,7 @@ on:
     branches: [ "main", "ci" ]
   pull_request:
     branches: [ "main", "ci" ]
-env:
-  VCGTEMPPATH: ${{ github.workspace }}/VCGTEMP/ # See the checkout step below for the path
+
 jobs:
   ci_tests:
     name: visualCaseGen CI tests
@@ -23,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          path: $VCGTEMPPATH
+          path: VCGTEMP
       # clone CESM
       - uses: actions/checkout@v4
         with:
@@ -37,12 +36,12 @@ jobs:
         env:
           GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
-          ./bin/git-fleximod update
+          ./CESM/bin/git-fleximod update
   
       # Checkout the correct visualCaseGen branch
       - name: Checkout initial event
         run: |
-          cp -r $VCGTEMPPATH/* CESM/visualCaseGen/
+          cp -r VCGTEMP/* CESM/visualCaseGen/
 
       # set up conda
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -19,12 +19,14 @@ jobs:
 
       - name: Install xmllint
         run: sudo apt-get install -y libxml2-utils
-      - uses: actions/checkout@v4
+      - name: Checkout VisualCaseGen to temp folder
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           path: VCGTEMP
       # clone CESM
-      - uses: actions/checkout@v4
+      - name: Checkout CESM
+        uses: actions/checkout@v4
         with:
           repository: alperaltuntas/CESM
           ref: cesm3_0_beta03_gui
@@ -39,8 +41,8 @@ jobs:
           cd CESM
           ./bin/git-fleximod update
   
-      # Checkout the correct visualCaseGen branch
-      - name: Checkout initial event
+      # Copy the checked out visualCaseGen branch to the CESM visualCaseGen folder
+      - name: Copy VCG checkout into the correct folder
         run: |
           cp -r VCGTEMP/* CESM/visualCaseGen/
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -34,7 +34,7 @@ jobs:
           #submodules: recursive
 
       # Run git-fleximod
-      - name: checkout CESM
+      - name: Checkout CESM submodules
         env:
           GIT_CLONE_PROTECTION_ACTIVE: false
         run: |

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -36,7 +36,8 @@ jobs:
         env:
           GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
-          ./CESM/bin/git-fleximod update
+          cd CESM
+          ./bin/git-fleximod update
   
       # Checkout the correct visualCaseGen branch
       - name: Checkout initial event

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,7 +7,8 @@ on:
     branches: [ "main", "ci" ]
   pull_request:
     branches: [ "main", "ci" ]
-
+env:
+  VCGTEMPPATH: ${{ github.workspace }}/VCGTEMP/ # See the checkout step below for the path
 jobs:
   ci_tests:
     name: visualCaseGen CI tests
@@ -22,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          path: VCG_temp
+          path: $VCGTEMPPATH
       # clone CESM
       - uses: actions/checkout@v4
         with:
@@ -39,11 +40,9 @@ jobs:
 
   
       # Checkout the correct visualCaseGen branch
-      - name: Checkout initial event (Pull Request)
+      - name: Checkout initial event
         run: |
-          echo "Handling pull request"
-          cd visualCaseGen/
-          cp -r ../VCG_temp/* .
+          cp -r $VCGTEMPPATH/* visualCaseGen/
 
       # set up conda
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -19,7 +19,10 @@ jobs:
 
       - name: Install xmllint
         run: sudo apt-get install -y libxml2-utils
-
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: VCG_temp
       # clone CESM
       - uses: actions/checkout@v4
         with:
@@ -34,23 +37,13 @@ jobs:
         run: |
           ./bin/git-fleximod update
 
+  
       # Checkout the correct visualCaseGen branch
       - name: Checkout initial event (Pull Request)
-        if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "Handling pull request"
           cd visualCaseGen/
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-${{ github.event.pull_request.number }}
-          git checkout pr-${{ github.event.pull_request.number }}
-          git submodule update --init
-
-      - name: Checkout initial event (Push)
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          echo "Handling push"
-          cd visualCaseGen/
-          git checkout ${{ github.sha }}
-          git submodule update --init
+          cp -r ../VCG_temp/* .
 
       # set up conda
       - uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -37,7 +37,8 @@ jobs:
           GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
           ./bin/git-fleximod update
-
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
   
       # Checkout the correct visualCaseGen branch
       - name: Checkout initial event

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           repository: alperaltuntas/CESM
           ref: cesm3_0_beta03_gui
+          path: CESM
           #submodules: recursive
 
       # Run git-fleximod
@@ -37,13 +38,11 @@ jobs:
           GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
           ./bin/git-fleximod update
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
   
       # Checkout the correct visualCaseGen branch
       - name: Checkout initial event
         run: |
-          cp -r $VCGTEMPPATH/* visualCaseGen/
+          cp -r $VCGTEMPPATH/* CESM/visualCaseGen/
 
       # set up conda
       - uses: conda-incubator/setup-miniconda@v3
@@ -51,7 +50,7 @@ jobs:
       # visualCaseGen conda env
       - name: Create visualCaseGen conda env
         run: |
-          cd visualCaseGen/
+          cd CESM/visualCaseGen/
           conda env create --file environment.yml
           conda activate visualCaseGen
     
@@ -64,7 +63,7 @@ jobs:
         run: |
           export SRC_PATH="${GITHUB_WORKSPACE}"
           mkdir -p /home/runner/cesm/scratch
-          cd visualCaseGen/
+          cd CESM/visualCaseGen/
           conda activate visualCaseGen
           pytest tests
 


### PR DESCRIPTION
Solve the VCG issue of checking out the wrong code in the CI (it fails b/c it can't find the code)


It used to be done by checking out the PR or pull request by SHA or PR Number, but that doesn't work on forks like CROCODILE-CESM. So instead, we checkout the correct codebase in a temp folder and then copy it into the CESM framework where it's supposed to be.

Two questions:

1. Same thing applies to MOM_interface, is it worth changing there?
2. This PR should probably go back to the original VCG as well. Should we PR there to?