### PR TITLE
Add Machine parameter to pass into CIME Machine

### DIFF
--- a/visualCaseGen/cime_interface.py
+++ b/visualCaseGen/cime_interface.py
@@ -39,7 +39,7 @@ class CIME_interface:
         List of resolutions (alias, compset, not_compset)
     """
 
-    def __init__(self, cesmroot=None):
+    def __init__(self, cesmroot=None, machine = None):
 
         # Set cimeroot attribute and import CIME modules
         self._set_cimeroot(cesmroot)
@@ -63,6 +63,7 @@ class CIME_interface:
         self._files = None
         self._grids_obj = None
         self.din_loc_root = None
+        self.machine = machine
 
         # Call _retrieve* methods to populate the data members defined above
         self._retrieve_cime_basics()
@@ -552,7 +553,6 @@ class CIME_interface:
         from CIME.XML.machines import Machines
 
         machs_file = self._files.get_value("MACHINES_SPEC_FILE")
-        self.machine = None
         self.cime_output_root = None
         self.din_loc_root = None
         self.project_required = {}


### PR DESCRIPTION
Fixes https://github.com/CROCODILE-CESM/CrocoDash/issues/33

Details:
In CrocoDash, we call CIME_interface(cesmroot) from VisualCaseGen. In the constructor, it calls CIME_interface.retrieve_machines, which discovers self.machine through the following lines:

```
machines_obj = Machines(machs_file, machine=self.machine)
self.machine = machines_obj.get_machine_name()
self.machines = machines_obj.list_available_machines()
```

`self.machine` is passed as `None` by default into the CIME `Machines` constructor (we set it as None in a previous line), so the constructor looks for the environment variable CIME_MACHINE (after which it goes into another step to search for the machine) to figure out what machine it is. 

That's not what we want because it fails & can't find ubuntu-latest when we set that in CrocoDash. To fix this, I just added a machine parameter (defaut set to None) to allow us to explicitly pass in the machine parameter to CIME Machines.


Questions:
Is this what we want? I wasn't sure if this was an explicit choice to not set self.machine & let CIME Machines discover it. It's a soft change so this won't change any other part of VCG.